### PR TITLE
絵文字がキモすぎる問題の修正

### DIFF
--- a/client/lib/nicommentJS.js
+++ b/client/lib/nicommentJS.js
@@ -13,6 +13,7 @@ class nicommentJS {
         this.color = params.color || '#FFF';
         this.width = params.width || 300;
         this.height = params.height || 300;
+        this.emojiEntityRegexp = new RegExp(String.raw`^\s*&#x`);
 
         this._setupApplication();
     }
@@ -49,8 +50,12 @@ class nicommentJS {
         comment.style.fontSize = fontSize + 'px';
         comment.style.color = color;
         comment.style.fontWeight = '600';
-        comment.style.textShadow = '0 0 3px #000';
-        comment.style.webkitTextStroke = '2px #000';
+        if (text.match(this.emojiEntityRegexp)) {
+            // no-op (絵文字に好適なスタイルがあったら設定する)
+        } else {
+            comment.style.textShadow = '0 0 3px #000';
+            comment.style.webkitTextStroke = '2px #000';
+        }
         comment.style.fontFamily = "'Arial','Hiragino Kaku Gothic ProN','ヒラギノ角ゴ ProN W3','メイリオ', sans-serif";
 
         this.app.appendChild(comment);

--- a/client/main.js
+++ b/client/main.js
@@ -56,11 +56,6 @@ function createWindow() {
     });
 }
 
-app.on('ready', () => {
-    addIpcListener();
-    createWindow();
-});
-
 app.on('window-all-closed', function () {
     if (process.platform !== 'darwin') {
         app.quit();
@@ -72,3 +67,5 @@ app.on('activate', function () {
         createWindow();
     }
 });
+
+app.whenReady().then(addIpcListener).then(createWindow);


### PR DESCRIPTION
ニコニコ風の文字を目立たせる/白背景で浮かないように textShadow が設定されているが、絵文字がキモいことになる

### expected
![no_shadow](https://user-images.githubusercontent.com/949492/125091095-13529080-e10b-11eb-98b9-27039a82b839.png)

### actual
![shadow](https://user-images.githubusercontent.com/949492/125091119-18174480-e10b-11eb-860b-790341d4fb93.png)

絵文字が含まれていた場合は textShadow を落とす。ただ、文字は textShadow がないと特に白背景で全く見えないため、絵文字で始まる場合(絵文字だけを想定)だけに適用する。末尾に絵文字+文字の場合は適用され(a)、先頭に絵文字+文字の場合は適用されない(b)になることになり、b は見づらいが、b はケースとしては少なそうなので制限(と言うよりは裏技くらいで)
