### PR TITLE
VSCode でのデバッグ用設定ファイルの追加

### DIFF
--- a/client/.vscode/launch.json
+++ b/client/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Debug Main Process",
+        "type": "node",
+        "request": "launch",
+        "cwd": "${workspaceRoot}",
+        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+        "windows": {
+          "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+        },
+        "args": ["."],
+        "protocol": "inspector",
+        "stopOnEntry": false
+      },
+      {
+        "name": "Debug Renderer Process",
+        "type": "chrome",
+        "request": "launch",
+        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+        "windows": {
+          "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+        },
+        "runtimeArgs": [
+          "${workspaceRoot}/main.js",
+          "--remote-debugging-port=9222"
+        ],
+        "webRoot": "${workspaceRoot}"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
もしデバッグは起動するがウィンドウが表示されない場合は、VSCode の settings.json に以下の値を入れて試してみること
`"debug.javascript.usePreview": false`