### PR TITLE
ホスト名埋め込みビルドに対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Slackに書かれたコメントを、ニコニコ風コメントとして画面
 
 ## 動作環境
 - node.js: v10.15.1
-- electron: v1.4.13
+- electron: v13.1.6
 
 ## プロジェクト構成
 
@@ -52,20 +52,43 @@ target url:      [https://niconico-slack-xxxxx-xxxxx.appspot.com]
 4. Install App
 
 ## クライアント
-アプリを起動すると画面の最前面に透明のウィンドウが表示される
+1. ホスト名を以下のうちいずれかに設定します。数字の通りの優先順で読み込まれます。※前バージョンまでの config/default.yaml は 2 のテンプレになりました。直接は読み込まれません。
+    1. 環境変数 `NICONICO_SLACK_HOSTNAME`
+        - 開発中または運用で一時的に値を上書きしたい場合の利用を想定
+    2. default.yaml の `hostname`
+        - 通常の設定ファイルとしての利用を想定
+        - 配置場所は以下の通りです。
+            - Windows: `%APPDATA%\niconico-slack-client`
+            - macOS: `~/Library/Application Support/niconico-slack-client`
+    3. package.json の `config.niconico_slack_name`
+        - 配布時点でアプリに値を埋め込んでおきたいケースの利用を想定
 
-Slack Botがメンションされると、コメントが流れてくるようになる
+2. アプリを起動すると画面の最前面に透明のウィンドウが表示される
+
+3. Slack Botがメンションされると、コメントが流れてくるようになる
+
+
 ```
-cd client/
-vim config/default.yaml
-> hostname: "niconico-slack-xxxxx-xxxxx.appspot.com" に書き換える
+# ホスト設定
+# > hostname を "niconico-slack-xxxxx-xxxxx.appspot.com" に書き換える
+# ※UTF-8 エンコーディングで保存してください
+
+## macOS
+cd ~/Library/Application Support/niconico-slack-client
+vim default.yaml
+
+## Windows
+cd %APP_DATA%\niconico-slack-client
+notepad default.yaml
 
 # ローカルでの動作確認(透明のウィンドウが立ち上がればOK)
 electron .
 
-# アプリにパッケージ
-electron-packager . niconico-slack --platform=darwin --arch=x64 --asar --electron-version=1.4.13 --icon=images/icon.icns
-(client/niconico-slack-darwin-x64/に.appが吐き出されている）
+# アプリにパッケージ(client/niconico-slack-[win32-64|darwin-x64]/に[exe|app]が吐き出される）
+## macOS
+npm run package:mac
+## Windows
+npm run package:win
 ```
 
 ## 実際に使う時

--- a/client/main.js
+++ b/client/main.js
@@ -1,23 +1,69 @@
-const { app, BrowserWindow, screen, ipcMain } = require('electron');
+const { app, BrowserWindow, screen, ipcMain, globalShortcut } = require('electron');
 const path = require('path');
 const yaml = require('js-yaml');
+const devToolHotKey = process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I';
 const Store = require('electron-store');
-const store = new Store({
-    fileExtension: 'yaml',
-    serialize: yaml.dump,
-    deserialize: yaml.load,
-    cwd: path.join(app.getPath('appData'), app.getName()),
-    name: 'default'
-});
 
 let mainWindow;
 
 function addIpcListener() {
+    const store = new Store({
+        fileExtension: 'yaml',
+        serialize: yaml.dump,
+        deserialize: yaml.load,
+        cwd: path.join(app.getPath('appData'), app.getName()),
+        name: 'default'
+    });
     ipcMain.on('get-host-config', (event, arg) => {
-        event.returnValue = store.get('config.hostname');
+        // ランタイムの環境変数 > 設定ファイル(default.yaml) > package.json 埋め込み値
+        const runtimeValue = process.env.NICONICO_SLACK_HOSTNAME;
+        const configValue = store.get('config.hostname');
+        const embeddedValue = require('./package.json').config.niconico_slack_hostname;
+        console.log(`runtime : ${runtimeValue}, config: ${configValue}, embedded: ${embeddedValue}`);
+        const targetHost = runtimeValue || configValue || embeddedValue;
+        console.log(`Hostname : ${targetHost}`);
+        event.returnValue = targetHost;
     });
     ipcMain.on('get-primary-display-size', (event, arg) => {
         event.returnValue = screen.getPrimaryDisplay().size;
+    });
+}
+
+function toggleDevTools(browserWindow) {
+    if (browserWindow.isDevToolsOpened()) {
+        browserWindow.closeDevTools();
+    } else {
+        browserWindow.openDevTools();
+    }
+}
+
+function registerLocalShortcut(browserWindow) {
+    globalShortcut.register(devToolHotKey, () => {
+        toggleDevTools(browserWindow);
+    });
+}
+
+function unregisterLocalShortcut(browserWindow) {
+    try {
+        globalShortcut.unregister(devToolHotKey);
+    } catch(e) {
+        // no-op
+        console.warn(`unregister shortcut failed. error = ${e}`);
+    }
+}
+
+function setupDevTools(browserWindow) {
+    app.on('browser-window-blur', () => {
+        unregisterLocalShortcut();
+    });
+    app.on('browser-window-focus', () => {
+        registerLocalShortcut(browserWindow);
+    });
+    app.on('browser-window-created', () => {
+        registerLocalShortcut(browserWindow);
+    });
+    app.on('window-all-closed', () => {
+        unregisterLocalShortcut();
     });
 }
 
@@ -44,8 +90,7 @@ function createWindow() {
 
     mainWindow.loadURL('file://' + __dirname + '/index.html');
 
-    // Open the DevTools.
-    // mainWindow.webContents.openDevTools()
+    //mainWindow.webContents.openDevTools()
 
     mainWindow.on('closed', function () {
         mainWindow = null;
@@ -54,6 +99,15 @@ function createWindow() {
     mainWindow.on('ready-to-show', () => {
         mainWindow.show();
     });
+
+    // CSS の指定が効かない場合があることのワークアラウンド
+    // https://github.com/electron/electron/issues/3534
+    const contents = mainWindow.webContents;
+    contents.on('dom-ready', () => {
+        contents.insertCSS('html,body{ overflow: hidden !important; }');
+    });
+
+    setupDevTools(mainWindow);
 }
 
 app.on('window-all-closed', function () {

--- a/client/package.json
+++ b/client/package.json
@@ -7,10 +7,15 @@
     "node": ">= 10.15.1"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "package:win": "node_modules/.bin/electron-packager . niconico-slack --platform=win32 --arch=x64 --asar --electron-version=13.1.6 --icon=images/icon.ico",
+    "package:mac": "node_modules/.bin/electron-packager . niconico-slack --platform=darwin --arch=x64 --asar --electron-version=13.1.6 --icon=images/icon.icns"
   },
   "author": "kengo92i",
   "license": "MIT",
+  "config": {
+    "niconico_slack_hostname": "niconico-slack-xxxxxx-xxxxx-packagejson.appspot.com"
+  },
   "dependencies": {
     "electron-store": "^8.0.0",
     "js-yaml": "^4.1.0"


### PR DESCRIPTION
 1. package.json によるホストの埋め込みに対応(本来はビルド時にランタイムで与えたものが埋め込まれる方が良い)、同時に、実行時の環境変数による上書きに対応
2. スクロールバーが再度表示されている問題の修正
3. DevTools をホットキー(Ctrl+Shift+I / Cmd+Alt+I)で表示できるようにした。
4. README の更新