### PR TITLE
最前面が外れる問題の対応

### DIFF
--- a/client/Config.js
+++ b/client/Config.js
@@ -10,6 +10,7 @@ const store = new Store({
     cwd: path.join(app.getPath('appData'), app.getName()),
     name: 'default'
 });
+const logger = require('./Logger');
 
 class Config {
     constructor() {
@@ -30,10 +31,10 @@ class Config {
         const configValue = store.get('config.hostname');
         // package.json の埋め込み値
         const embeddedValue = packageJson.config.niconico_slack_hostname;
-        console.log(`runtime : ${runtimeValue}, config: ${configValue}, embedded: ${embeddedValue}`);
+        logger.info(`Host env : ${runtimeValue}, config: ${configValue}, embedded: ${embeddedValue}`);
         // 優先順位: ランタイムの環境変数 > 設定ファイル > package.json 埋め込み値
         const targetHost = runtimeValue || configValue || embeddedValue;
-        console.log(`Hostname : ${targetHost}`);
+        logger.info(`Target host : ${targetHost}`);
         return targetHost;
     }
 

--- a/client/SlackMessage.js
+++ b/client/SlackMessage.js
@@ -3,6 +3,7 @@ const EventEmitter2 = require('eventemitter2');
 const emoji = require('./resources/slack_emoji.json');
 const reRegExp = /[\\^$.*+?()[\]{}|]/g;
 const reHasRegExp = new RegExp(reRegExp.source);
+const logger = require('./Logger');
 
 class SlackMessage extends EventEmitter2 {
 
@@ -35,13 +36,13 @@ class SlackMessage extends EventEmitter2 {
         }
         this.socketio = io('https://' + targetHost);
         this.socketio.on('connection', () => {
-            console.log('connected!');
+            logger.debug('connected!');
         });
         this.socketio.on('connect_error', (err) => {
-            console.error(`connect failed. err=${err}`);
+            logger.warn(`connect failed. err=${err}`);
         });
         this.socketio.on('message', (msg) => {
-            console.log('message receive: ' + msg);
+            logger.info('message receive: ' + msg);
             if (!msg) { return; } // msgがnullの時があるので
             msg = msg.replace(/<@.*>/, '');
             const columnCount = (msg.match(this.emojiColumn) || []).length;

--- a/client/main.js
+++ b/client/main.js
@@ -205,15 +205,7 @@ function createWindow() {
 }
 
 app.on('window-all-closed', function () {
-    if (!isMac) {
-        app.quit();
-    }
-});
-
-app.on('activate', function () {
-    if (niconicoWindow === null) {
-        createWindow();
-    }
+    app.quit();
 });
 
 function logAppInfo() {

--- a/client/main.js
+++ b/client/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, screen, ipcMain, Tray, Menu, Notification } = require('electron');
+const { app, BrowserWindow, screen, ipcMain, Tray, Menu } = require('electron');
 const isMac = process.platform === 'darwin';
 const logger = require('./Logger');
 const path = require('path');
@@ -149,15 +149,21 @@ function setupTray() {
 
         { type: 'separator' },
         {
-            label: 'alwaysOnTop', type: 'checkbox', checked: niconicoWindow.isAlwaysOnTop(), click: (r) => {
+            label: 'Always on top', type: 'checkbox', checked: niconicoWindow.isAlwaysOnTop(), click: (r) => {
                 updateAlwaysOnTop(r.checked);
             }
         },
-        { label: 'openDevTools', type: 'normal', click: () => {
-            updateWindowAttributeForDebug();
-            niconicoWindow.openDevTools();
-            new Notification({ title: app.getName(), body: `Changed window attribute to start DevTools. Please restart the application after debugging.`}).show();
-        } },
+        {
+            label: 'Open Chrome DevTools', type: 'normal', click: () => {
+                updateWindowAttributeForDebug();
+                niconicoWindow.openDevTools();
+                const message = `Changed window attribute to start Chrome DevTools. Please restart the application after debugging.`;
+                tray.displayBalloon({
+                    title: app.getName(),
+                    content: message
+                });
+            }
+        },
         { type: 'separator' },
         {
             label: 'Exit', type: 'normal', click: () => {
@@ -206,8 +212,8 @@ function createWindow() {
             preload: path.join(app.getAppPath(), 'niconicoRenderer.js')
         },
         focusable: false    // Windows における前面移動時の flash を避けるため。
-                            // macOS では app.dock.hide() で Dock も隠せるが、
-                            // 強制終了手段が塞がれる可能性があることからやらない
+        // macOS では app.dock.hide() で Dock も隠せるが、
+        // 強制終了手段が塞がれる可能性があることからやらない
     });
     niconicoWindow.setIgnoreMouseEvents(true);
     niconicoWindow.maximize();

--- a/client/main.js
+++ b/client/main.js
@@ -1,9 +1,10 @@
-const { app, BrowserWindow, screen, ipcMain, Tray, Menu } = require('electron');
+const { app, BrowserWindow, screen, ipcMain, Tray, Menu, Notification } = require('electron');
 const isMac = process.platform === 'darwin';
 const logger = require('./Logger');
 const path = require('path');
 const config = require('./Config');
 const slackMessage = require('./SlackMessage');
+const { title } = require('process');
 let pollIntervalId;
 
 let niconicoWindow;
@@ -157,11 +158,19 @@ function setupTray() {
             label: 'Open Chrome DevTools', type: 'normal', click: () => {
                 updateWindowAttributeForDebug();
                 niconicoWindow.openDevTools();
+                const title = app.getName();
                 const message = `Changed window attribute to start Chrome DevTools. Please restart the application after debugging.`;
-                tray.displayBalloon({
-                    title: app.getName(),
-                    content: message
-                });
+                if (isMac) {
+                    new Notification({
+                        title: title,
+                        body: message
+                    }).show();
+                } else {
+                    tray.displayBalloon({
+                        title: title,
+                        content: message
+                    });
+                }
             }
         },
         { type: 'separator' },


### PR DESCRIPTION
原因不明だが alwaysOnTop=true にも関わらずコメントが裏に行く場合がある。フォーカスすると戻る。
ワークアラウンドだが、定期的に setAlwaysOnTop を true にし、フォーカスするようにして回避。
この際、Windows ではタスクバーがチラつく。タスクトレイを先般実装し、こちらだけの方がスマートなため、タスクトレイは外すようにした。macOS ではタスクバーがバウンドすることはないのと、暴走した場合メニューバーも含めてマウスが押せない状況が見られたことから、Dockのアイコンはそのまま。